### PR TITLE
feat: Add 'Jefe' proactive coding assistant persona

### DIFF
--- a/cheating-daddy-element.js
+++ b/cheating-daddy-element.js
@@ -669,6 +669,11 @@ class CheatingDaddyApp extends LitElement {
                 description: 'Get help with answering interview questions',
             },
             {
+                value: 'jefe',
+                name: 'Jefe (Coding Asst.)',
+                description: 'Proactive coding assistance based on screen and audio',
+            },
+            {
                 value: 'sales',
                 name: 'Sales Call',
                 description: 'Assist with sales conversations and objection handling',
@@ -724,6 +729,7 @@ class CheatingDaddyApp extends LitElement {
         ];
 
         const profileNames = {
+            jefe: 'Jefe (Coding Asst.)',
             interview: 'Job Interview',
             sales: 'Sales Call',
             meeting: 'Business Meeting',

--- a/prompts.js
+++ b/prompts.js
@@ -1,4 +1,20 @@
 const profilePrompts = {
+    jefe: `
+You are Jefe, an AI coding assistant.
+Proactively analyze the user's screen content:
+\`\`\`
+${screenContent}
+\`\`\`
+and audio transcript:
+\`\`\`
+${audioTranscript}
+\`\`\`
+Provide immediate, concise coding assistance. Do not wait to be asked.
+Respond in 3 lines:
+🔧 [ISSUE/CONTEXT]
+💡 [SUGGESTION/SOLUTION]
+⚡ [RELEVANT TIP/SHORTCUT]
+`,
     interview: `
 You are an AI-powered interview assistant, designed to act as a discreet on-screen teleprompter. Your mission is to help the user excel in their job interview by providing concise, impactful, and ready-to-speak answers or key talking points. Analyze the ongoing interview dialogue and, crucially, the 'User-provided context' below.
 


### PR DESCRIPTION
This commit introduces the 'Jefe' persona, a proactive coding assistant designed to analyze screen and audio content and provide immediate, unprompted assistance.

Changes include:

1.  **prompts.js**:
    *   Added a new system prompt for the 'Jefe' persona (`jefe`).
    *   This prompt instructs me to identify as 'Jefe', proactively analyze screen content (images) and audio (speech), and offer coding help using a concise 3-line format.

2.  **cheating-daddy-element.js**:
    *   Added 'Jefe (Coding Asst.)' to the selectable profiles in the UI's customization view.
    *   This ensures that when the 'Jefe' profile is selected, the corresponding system prompt is loaded for my session.

I will continue to receive screen images and raw audio data as before. The 'Jefe' system prompt will guide my behavior and responses based on my interpretation of this multimedia context, aligning with your requirement for a proactive assistant that doesn't wait to be asked for help.